### PR TITLE
feat: make application scope and orchestrator url inputs optional

### DIFF
--- a/.commitsar.yaml
+++ b/.commitsar.yaml
@@ -1,0 +1,7 @@
+version: 1
+verbose: true
+commits:
+  strict: true
+  disabled: false
+pull_request:
+  conventional: true

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,25 @@
+# This is a workflow to check the contents of a pull request to main
+
+name: PR Checks
+
+# Controls when the workflow will run
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  commitsar:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Commitsar
+        uses: aevea/commitsar@v0.20.2
+        with: 
+          config: .commitsar.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,28 +1,52 @@
 # UiPath-Deploy
 GitHub action for deploying all .nupkg packages in a provided path to UiPath Orchestrator using the [package deploy task from the UiPath CLI](https://docs.uipath.com/test-suite/automation-cloud/latest/user-guide/deploying-a-package-to-orchestrator).
 
-## Example usage:
+**Note:** The current version of this action is only compatible with Windows runners
+
+## Setup
+
+This action requires the following items to be configured:
+- UiPath CLI installed on GitHub Actions Runner. This can be done by running the [setup-uipath action](https://github.com/Mikael-RnD/setup-uipath) before this action
+- [An external application created in Orchestrator](https://docs.uipath.com/automation-cloud/automation-cloud/latest/admin-guide/managing-external-applications) with the access scopes specified in the [UiPath CLI documentation](https://docs.uipath.com/test-suite/automation-cloud/latest/user-guide/executing-tasks-cli). With the credentials passed to this actions input from GitHub Secrets (or other safe credential stores)
+
+## Example usage
+
+### Required inputs only
 
       # .nupkg packages are deployed to UiPath Orchestrator
       - name: UiPath Deploy
         uses: Mikael-RnD/UiPath-Deploy@v1
         with:
-          # All inputs are required
           packagesPath: ${{ github.workspace }}
-          orchestratorUrl: https://cloud.uipath.com/
-          orchestratorTenant: # Name of tenant where packages are deployed
-          orchestratorFolder: # Orchestrator Folder path where packages are deployed
-          orchestratorApplicationId: # Id of External Application in Orchestrator
-          orchestratorApplicationSecret: # Application Secret for External Application in Orchestrator
-          orchestratorLogicalName: # Orchestrator logical name. Also known as organization id or account for app
+          orchestratorTenant: MyTenant
+          orchestratorFolder: "MyFolder/Test" 
+          orchestratorApplicationId: ${{ secrets.ORCHESTRATOR_APP_ID }}
+          orchestratorApplicationSecret: ${{ secrets.ORCHESTRATOR_APP_SECRET }}
+          orchestratorLogicalName: myorg
+
+### All inputs used
+
+      # .nupkg packages are deployed to UiPath Orchestrator
+      - name: UiPath Deploy
+        uses: Mikael-RnD/UiPath-Deploy@v1
+        with:
+          packagesPath: ${{ github.workspace }}
+          orchestratorUrl: https://mycompany.orchestrator.com/
+          orchestratorTenant: MyTenant
+          orchestratorFolder: "MyFolder/Test" 
+          orchestratorApplicationId: ${{ secrets.ORCHESTRATOR_APP_ID }}
+          orchestratorApplicationSecret: ${{ secrets.ORCHESTRATOR_APP_SECRET }}
+          orchestratorLogicalName: myorg
+          orchestratorApplicationScope: "OR.Assets OR.BackgroundTasks OR.Execution OR.Folders OR.Jobs OR.Machines.Read OR.Monitoring OR.Robots.Read OR.Settings.Read OR.TestSets OR.TestSetExecutions OR.TestSetSchedules OR.Users.Read"
 
 ## Inputs 
-|Name|Description|Required|Example value|
+|Name|Description|Required|Default value|
 |:--|:--|:--|:--|
-|packagesPath|Path to a directory containing .nupkg packages for deployment to Orchestrator|True|./packages|
-|orchestratorUrl|Base URL to Orchestrator instance|True|https://cloud.uipath.com/|
-|orchestratorTenant|Name of the Orchestrator tenant|True|TestTenant|
-|orchestratorLogicalName|Id of the UiPath organization|True|testorg|
-|orchestratorFolder|The fully qualified name of the Orchestrator folder where processes are deployed to|True|Finance/SE|
-|orchestratorApplicationId|Application ID for the CLI to authenticate with UiPath Orchestrator|True||
-|orchestratorApplicationSecret|Application Secret for the CLI to authenticate with UiPath Orchestrator|True||
+|**packagesPath**|Path to a directory containing .nupkg packages for deployment to Orchestrator|True|./packages|
+|**orchestratorUrl**|Base URL to Orchestrator instance|False|https://cloud.uipath.com/|
+|**orchestratorTenant**|Name of the Orchestrator tenant|True|TestTenant|
+|**orchestratorLogicalName**|Id of the UiPath organization|True|testorg|
+|**orchestratorFolder**|The fully qualified name of the Orchestrator folder where processes are deployed to|True|Finance/SE|
+|**orchestratorApplicationId**|Application ID for the CLI to authenticate with UiPath Orchestrator|True||
+|**orchestratorApplicationSecret**|Application Secret for the CLI to authenticate with UiPath Orchestrator|True||
+|**orchestratorApplicationScope**|The accesss scope setup for the external application|False|"OR.Assets OR.BackgroundTasks OR.Execution OR.Folders OR.Jobs OR.Machines.Read OR.Monitoring OR.Robots.Read OR.Settings.Read OR.TestSets OR.TestSetExecutions OR.TestSetSchedules OR.Users.Read"|

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,8 @@ inputs:
     required: true
   orchestratorUrl: 
     description: 'Orchestrator instance URL'
-    required: true
+    required: false
+    default: 'https://cloud.uipath.com/'
   orchestratorTenant:
     description: 'Tenant on the Orchestrator instance'
     required: true
@@ -22,7 +23,8 @@ inputs:
     required: true
   orchestratorApplicationScope:
     description: 'Access scope for external application'
-    required: true
+    required: false
+    default: "OR.Assets OR.BackgroundTasks OR.Execution OR.Folders OR.Jobs OR.Machines.Read OR.Monitoring OR.Robots.Read OR.Settings.Read OR.TestSets OR.TestSetExecutions OR.TestSetSchedules OR.Users.Read"
   orchestratorLogicalName:
     description: 'Logical name for Orchestrator organization'
     required: true


### PR DESCRIPTION
Make the inputs for Orchestrator URL and Application scope optional by providing default values matching the
most common use cases. 

The orchestratorUrl defaults to an instance of Orchestrator in UiPath Automation Cloud