### PR TITLE
feat: make packagesPath input optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This action requires the following items to be configured:
 
 |Name|Description|Required|Default value|
 |:--|:--|:--|:--|
-|**packagesPath**|Path to a directory containing .nupkg packages for deployment to Orchestrator|True||
+|**packagesPath**|Path to a directory containing .nupkg packages for deployment to Orchestrator|False|`${{ github.workspace }}`|
 |**orchestratorUrl**|Base URL to Orchestrator instance|False|<https://cloud.uipath.com/>|
 |**orchestratorTenant**|Name of the Orchestrator tenant|True||
 |**orchestratorLogicalName**|Id of the UiPath organization|True||

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,8 @@ description: 'Deploys .nupkg packages in the Github workspace directory to UiPat
 inputs:
   packagesPath:
     description: 'Relative path to a folder containing the .nupkg to be deployed'
-    required: true
+    required: false
+    default: ${{ github.workspace }}
   orchestratorUrl: 
     description: 'Orchestrator instance URL'
     required: false


### PR DESCRIPTION
Make packagesPath input optional, with the assumption that the GitHub workspace contains all packages to be deployed